### PR TITLE
Create request queue for all API requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -632,7 +632,7 @@
                 <span class="u-pull-left">
                     <a href="https://github.com/jstnryan/helium-reward-log">Read about this app and view the code on GitHub.</a>
                 </span>
-                <span id="version" class="u-pull-right">v1.2.3</span>
+                <span id="version" class="u-pull-right">v1.3.0</span>
             </div>
         </div>
     </body>


### PR DESCRIPTION
The Helium API really doesn't like concurrent requests from the same host, so this change creates a XMLHttpRequest queue (very similar to the one created for Binance requests) which processes one request at a time, and pauses for a random time (0 to 10 seconds) if the server responds with a 429 error.

Version bump to "1.3.0"