### PR TITLE
Enforce strict rate limiting

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -446,3 +446,37 @@ there.
 
 /* Larger than Desktop HD */
 @media (min-width: 1200px) {}
+
+
+/* Custom
+–––––––––––––––––––––––––––––––––––––––––––––––––– */
+.notify {
+  border: 1px solid #E1E1E1;
+  border-radius: 4px;
+  margin-bottom: 25px;
+  padding: 25px;
+}
+.notify-icon {
+  float: left;
+  height: 24px;
+  margin-right: 16px;
+  width: 24px;
+}
+.notify-content {
+  margin-left: 40px;
+}
+.notify-content *:last-child {
+  margin-bottom: 0;
+}
+.info {
+  background-color: rgba(243, 192, 51, 0.2);
+}
+.notify.info {
+  fill: #F3C033;
+}
+.warn {
+  background-color: rgba(239, 52, 30, 0.2);
+}
+.notify.warn {
+  fill: #EF341E;
+}

--- a/index.html
+++ b/index.html
@@ -15,6 +15,14 @@
             <div class="header">
                 <h2>Helium Reward Log</h2>
             </div>
+            <div class="notify info">
+                <svg class="notify-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M21 12a9 9 0 1 1-9-9 9 9 0 0 1 9 9zM10.5 7.5A1.5 1.5 0 1 0 12 6a1.5 1.5 0 0 0-1.5 1.5zm-.5 3.54v1h1V18h2v-6a.96.96 0 0 0-.96-.96z"></path></svg>
+                <div class="notify-content">
+                    <p><b>This may take a while.</b> Because of heavy use, recently the Helium API has been increasingly restrictive about the speeds at which requests can be made. If this app detects that the API is rejecting
+                        requests it will attempt to throttle connections. However, this means that some queries may take a long time to complete. If possible, try to split queries with a large timespan into shorter intervals.</p>
+                    <p>Additionally, this app is affected by Helium API maintenance or downtime. <a href="https://status.helium.com" target="_blank">Check API status.</a></p>
+                </div>
+            </div>
             <div class="request-form">
                 <form>
                     <div class="row">
@@ -616,7 +624,7 @@
                 </form>
             </div>
             <div id="status-area" style="text-align: center;" class="u-hidden">
-                <p><b id="status-message">Please wait...</b></p>
+                <p><b>Requests made</b>: <span id="status-requests">0</span> &nbsp; <b>Status</b>: <span id="status-message">Please wait...</span></p>
             </div>
             <div id="reward-toggles" class="u-hidden">
                 <label>Show / Hide Columns:</label>
@@ -694,7 +702,7 @@
                 <span class="u-pull-left">
                     <a href="https://github.com/jstnryan/helium-reward-log">Read about this app and view the code on GitHub.</a>
                 </span>
-                <span id="version" class="u-pull-right">v1.4.0</span>
+                <span id="version" class="u-pull-right">v1.4.1</span>
             </div>
         </div>
     </body>


### PR DESCRIPTION
Helium have begun enforcing very strict rate-limits when accessing the public API (api.helium.io), most certainly due to frequent outages and slow performance. This revision tracks the number of previous errored calls and increases the delay between subsequent calls in order to mitigate this.

A notification is now displayed prominently at the top of the page to illustrate this issue to users, as well as providing a link to Helium's network status page.

This change also improves UI feedback, namely a request counter which can be used as an indicator of whether the script has stalled.

Version bump to v1.4.1